### PR TITLE
Kecleon Infinite Money Glitch Fix

### DIFF
--- a/src/dungeon_serializer.c
+++ b/src/dungeon_serializer.c
@@ -738,6 +738,7 @@ void ReadDungeonState(u8 *buffer, u32 bufLen)
     ReadDungeonFloor(&seri);
     ReadDungeonVisibility(&seri);
     ReadDungeonMusic(&seri);
+    gDungeon->unk644.unk4C = 0; //KECLEON INFINITE MONEY GLITCH FIX: The game erroneously re-adds the total value of the items you're planning to sell in Kecleon's shop in ReadDungeonItems, which makes Kecleon give the player money whenever the player leaves the shop.
     ReadDungeonItems(&seri);
     ReadDungeonTraps(&seri);
     ReadDungeonMonsters(&seri);


### PR DESCRIPTION
I did not compile and test this - you should test it to be safe, but I'm pretty sure it works. I wrote an [equivalent in assembly](https://github.com/MkTr/Red-Rescue-Team-ROM-and-RAM-notes/blob/main/infinitemoneyglitch_fix.asm) which is proven to work, and I know gDungeon->unk644.unk4C is the variable I'm looking for because it's incremented by GetActualSellPrice() in SpawnItem() within dungeon_items.c.